### PR TITLE
Set minimum deployment target to MacOS 10.13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
   name: "MEWwalletKit",
   platforms: [
     .iOS(.v11),
-    .macOS(.v10_12)
+    .macOS(.v10_13)
   ],
   products: [
     .library(


### PR DESCRIPTION
Fixes compile error for using MacOS 10.13 API in library